### PR TITLE
Enable interrups on startup (UF2 Loader compatiblity)

### DIFF
--- a/bin/tinygo/picocalc/main.go
+++ b/bin/tinygo/picocalc/main.go
@@ -82,7 +82,7 @@ func (ic *interruptCheck) delaySleepFn(r *rpn.RPN, t float64) error {
 }
 
 func main() {
-	// Enable interrupts when using UF2 Loader (bootloader) interrups are disabled when main is called
+	// Enable interrupts. When using UF2 Loader (bootloader) interrupts are disabled when main is called
 	arm.EnableInterrupts(0)
 
 	time.Sleep(200 * time.Millisecond)

--- a/bin/tinygo/picocalc/main.go
+++ b/bin/tinygo/picocalc/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"device/arm"
 	"errors"
 	"machine"
 	"mattwach/rpngo/bin/tinygo"
@@ -81,6 +82,9 @@ func (ic *interruptCheck) delaySleepFn(r *rpn.RPN, t float64) error {
 }
 
 func main() {
+	// Enable interrupts when using UF2 Loader (bootloader) interrups are disabled when main is called
+	arm.EnableInterrupts(0)
+
 	time.Sleep(200 * time.Millisecond)
 	// This only seeems to work for panics I throw and not errors
 	// like array out of bounds.


### PR DESCRIPTION
When using the UF2 Loader ( https://github.com/pelrun/uf2loader ) the interrupts have to be enabled on startup. 

With this change rpngo (with sdcard storage) can be flashed and used with the UF2 Loader.